### PR TITLE
Feat dt common

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,6 +1,7 @@
 <!-- docs/_sidebar.md -->
 - [快速开始](quickstart.md)
 - [Utils](utils.md)
+- [DateTime](dateTime.md)
 - [Cookie](cookie.md)
 - [Layout](layout.md)
 - [CopyUtils](copy.md)

--- a/docs/dateTime.md
+++ b/docs/dateTime.md
@@ -1,0 +1,55 @@
+# DateTime
+
+导入
+
+```js
+import { DateTime } from "@dtinsight/dt-utils";
+```
+
+## formatDateTime
+
+返回 `YYYY-MM-DD HH:mm:ss` 格式化的字符串
+
+```js
+DateTime.formatDateTime(1627457470000);
+```
+
+## formatDate
+
+返回 `YYYY-MM-DD` 格式化的字符串
+
+```js
+DateTime.formatDate(1627457470000);
+```
+
+## formatDateHours
+
+返回 `YYYY-MM-DD HH:mm` 格式化的字符串
+
+```js
+DateTime.formatDateHours(1627457470000);
+```
+
+## formatDayHours
+
+返回 `MM-DD HH:mm` 格式化的字符串
+
+```js
+DateTime.formatDayHours(1627457470000);
+```
+
+## formatHours
+
+返回 `HH:mm` 格式化的字符串
+
+```js
+DateTime.formatHours(1627457470000);
+```
+
+## formatMinute
+
+返回 `HH:mm:ss` 格式化的字符串
+
+```js
+DateTime.formatMinute(1627457470000);
+```

--- a/docs/dateTime.md
+++ b/docs/dateTime.md
@@ -53,3 +53,13 @@ DateTime.formatHours(1627457470000);
 ```js
 DateTime.formatMinute(1627457470000);
 ```
+
+## formatSecond
+
+把秒数转换成 3h5m11s 的格式
+
+```js
+DateTime.formatSecond(11111); // 3h5m11s
+DateTime.formatSecond(111); // 1m51s
+DateTime.formatSecond(11); // 11s
+```

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.7.7",
+    "@commitlint/config-conventional": "^9.1.1",
     "@microsoft/api-extractor": "^7.7.0",
     "@types/fs-extra": "^8.0.1",
     "@types/gulp": "^4.0.6",
@@ -45,6 +46,7 @@
     "commitizen": "^4.0.3",
     "commitlint": "^8.2.0",
     "conventional-changelog-cli": "^2.0.31",
+    "docsify-cli": "^4.4.1",
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.1.1",
     "fs-extra": "^8.1.0",
@@ -62,11 +64,10 @@
     "ts-jest": "^24.2.0",
     "ts-node": "^8.5.4",
     "typescript": "^3.7.4",
-    "vue-cli-plugin-commitlint": "^1.0.4",
-    "@commitlint/config-conventional": "^9.1.1",
-    "docsify-cli": "^4.4.1"
+    "vue-cli-plugin-commitlint": "^1.0.4"
   },
   "dependencies": {
+    "dayjs": "^1.10.6",
     "lodash": "^4.17.15"
   },
   "config": {

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -7,7 +7,13 @@ const cookie = {
         const arr = document.cookie.match(
             new RegExp('(^| )' + name + '=([^;]*)(;|$)')
         );
-        if (arr != null) { return unescape(decodeURI(arr[2])); }
+        if (arr != null) {
+            try {
+                return unescape(decodeURI(arr[2]));
+            } catch (error) {
+                return arr[2];
+            }
+        }
         return null;
     },
 
@@ -16,7 +22,7 @@ const cookie = {
         domain = domain ? `; domain=${domain}` : '';
         path = path || '/';
         document.cookie =
-      name + '=; expires=' + d.toUTCString() + domain + '; path=' + path;
+            name + '=; expires=' + d.toUTCString() + domain + '; path=' + path;
     },
 
     deleteAllCookies (domain: string, path: string) {
@@ -29,14 +35,18 @@ const cookie = {
         }
     },
 
-    setCookie (name: string, value: string | number | object | boolean, days?: number) {
+    setCookie (name: string, value: string | number | object | boolean, days?: number, domainStr?: string) {
         let expires = '';
         if (days) {
             const date = new Date();
             date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
             expires = '; expires=' + date.toUTCString();
         }
-        document.cookie = name + '=' + value + expires + '; path=/';
+        let domain = '';
+        if (domainStr) {
+            domain = '; domain=' + domainStr;
+        }
+        document.cookie = name + '=' + value + expires + domain + '; path=/';
     },
 };
 

--- a/src/dateTime.ts
+++ b/src/dateTime.ts
@@ -1,0 +1,62 @@
+/**:
+ * @description: 时间格式化
+ * @author: Created by 景明 on 2021-08-26 15:57:25
+ */
+
+import dayjs from 'dayjs';
+
+/**
+ * 树形布局计算
+ */
+const dateTime = {
+    /**
+   * 返回 YYYY-MM-DD HH:mm:ss 格式化的字符串
+   * @param {string | number | Date} timeData
+   * @return {string}
+   */
+    formatDateTime (timeData: string | number | Date) {
+        return dayjs(timeData).format('YYYY-MM-DD HH:mm:ss');
+    },
+    /**
+   * 返回 YYYY-MM-DD 格式化的字符串
+   * @param {string | number | Date} timeData
+   * @return {string}
+   */
+    formatDate (timeData: string | number | Date) {
+        return dayjs(timeData).format('YYYY-MM-DD');
+    },
+    /**
+   * 返回 YYYY-MM-DD HH:mm 格式化的字符串
+   * @param {string | number | Date} timeData
+   * @return {string}
+   */
+    formatDateHours (timeData: string | number | Date) {
+        return dayjs(timeData).format('YYYY-MM-DD HH:mm');
+    },
+    /**
+   * 返回 MM-DD HH:mm 格式化的字符串
+   * @param {string | number | Date} timeData
+   * @return {string}
+   */
+    formatDayHours (timeData: string | number | Date) {
+        return dayjs(timeData).format('MM-DD HH:mm');
+    },
+    /**
+   * 返回 HH:mm 格式化的字符串
+   * @param {string | number | Date} timeData
+   * @return {string}
+   */
+    formatHours (timeData: string | number | Date) {
+        return dayjs(timeData).format('HH:mm');
+    },
+    /**
+   * 返回 HH:mm:ss 格式化的字符串
+   * @param {string | number | Date} timeData
+   * @return {string}
+   */
+    formatMinute (timeData: string | number | Date) {
+        return dayjs(timeData).format('HH:mm:ss');
+    },
+};
+
+export default dateTime;

--- a/src/dateTime.ts
+++ b/src/dateTime.ts
@@ -57,6 +57,31 @@ const dateTime = {
     formatMinute (timeData: string | number | Date) {
         return dayjs(timeData).format('HH:mm:ss');
     },
+    /**
+   * 把秒转换成 HH[h]mm[m]ss[s] 的格式
+   * @param {number} secondTime 秒
+   * @return {string}
+   */
+    formatSecond (secondTime = 0) {
+        let second = 0;
+        let minute = 0;
+        let hour = 0;
+
+        function _formatHour (timestap: number) {
+            hour = Math.floor(timestap / 3600);
+            return timestap - hour * 3600;
+        }
+        function _formatMinute (timestap: number) {
+            minute = Math.floor(timestap / 60);
+            return timestap - minute * 60;
+        }
+        function _formatSecond (timestap: number) {
+            second = timestap;
+            return second;
+        }
+        _formatSecond(_formatMinute(_formatHour(secondTime)));
+        return `${hour ? hour + 'h' : ''}${minute ? minute + 'm' : ''}${second ? second + 's' : ''}` || '0s';
+    },
 };
 
 export default dateTime;

--- a/src/dateTime.ts
+++ b/src/dateTime.ts
@@ -6,7 +6,7 @@
 import dayjs from 'dayjs';
 
 /**
- * 树形布局计算
+ * 时间处理
  */
 const dateTime = {
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Utils } from './utils';
+export { default as DateTime } from './dateTime';
 export { default as Layout } from './layout';
 export { default as Cookie } from './cookie';
 export { default as LocalDB } from './localDB';

--- a/src/localDB.ts
+++ b/src/localDB.ts
@@ -27,7 +27,7 @@ const localDb = {
      */
     get (key: string|number) {
         const str = window.localStorage[key] || '';
-        return Utils.isJSONStr(str) ? JSON?.parse(str) : str;
+        return Utils.isJSONStr(str) ? JSON.parse(str) : str;
     },
     /**
      * 清空localStorage

--- a/src/localDB.ts
+++ b/src/localDB.ts
@@ -1,3 +1,4 @@
+import Utils from './utils';
 /**
  * 封装localStorage
  * 增加对JSON对象的转换
@@ -26,13 +27,7 @@ const localDb = {
      */
     get (key: string|number) {
         const str = window.localStorage[key] || '';
-        function isJSONStr (str: string) {
-            return (
-                (str.charAt(0) === '{' && str.charAt(str.length - 1) === '}') ||
-                (str.charAt(0) === '[' && str.charAt(str.length - 1) === ']')
-            );
-        }
-        return isJSONStr(str) ? JSON.parse(str) : str;
+        return Utils.isJSONStr(str) ? JSON?.parse(str) : str;
     },
     /**
      * 清空localStorage

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -219,7 +219,7 @@ const utils = {
         str = this.trimlr(str);
         return (
             (str.charAt(0) === '{' && str.charAt(str.length - 1) === '}') ||
-      (str.charAt(0) === '[' && str.charAt(str.length - 1) === ']')
+            (str.charAt(0) === '[' && str.charAt(str.length - 1) === ']')
         );
     },
     /**
@@ -296,7 +296,7 @@ const utils = {
     isEqual (a: any, b: any): boolean {
         for (const key in a) {
             if ({}.hasOwnProperty.call(a, key) &&
-        (!{}.hasOwnProperty.call(b, key) || a[key] !== b[key])) {
+          (!{}.hasOwnProperty.call(b, key) || a[key] !== b[key])) {
                 return false;
             }
         }

--- a/test/dateTime.test.ts
+++ b/test/dateTime.test.ts
@@ -1,0 +1,120 @@
+import DateTime from '../src/dateTime';
+const {
+    formatDate,
+    formatDateHours,
+    formatDateTime,
+    formatDayHours,
+    formatHours,
+    formatMinute,
+} = DateTime;
+
+describe('utils.dateTime', () => {
+    test('formatDate timestamp to YYYY-MM-DD', () => {
+        const dateTime = 1627457470000;
+        const expected = '2021-07-28';
+        const newVal = formatDate(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatDate string to YYYY-MM-DD', () => {
+        const dateTime = '2021-07-28';
+        const expected = '2021-07-28';
+        const newVal = formatDate(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatDate number to YYYY-MM-DD', () => {
+        const dateTime = 11111111111;
+        const expected = '1970-05-09';
+        const newVal = formatDate(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatDateHours timestamp to YYYY-MM-DD HH:mm', () => {
+        const dateTime = 1627457470000;
+        const expected = '2021-07-28 15:31';
+        const newVal = formatDateHours(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatDateHours string to YYYY-MM-DD HH:mm', () => {
+        const dateTime = '2021-07-28 15:31';
+        const expected = '2021-07-28 15:31';
+        const newVal = formatDateHours(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatDateHours number to YYYY-MM-DD HH:mm', () => {
+        const dateTime = 11111111111;
+        const expected = '1970-05-09 22:25';
+        const newVal = formatDateHours(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatDateTime timestamp to YYYY-MM-DD HH:mm:ss', () => {
+        const dateTime = 1627457470000;
+        const expected = '2021-07-28 15:31:10';
+        const newVal = formatDateTime(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatDateTime string to YYYY-MM-DD HH:mm:ss', () => {
+        const dateTime = '2021-07-28 15:31:10';
+        const expected = '2021-07-28 15:31:10';
+        const newVal = formatDateTime(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatDateTime number to YYYY-MM-DD HH:mm:ss', () => {
+        const dateTime = 11111111111;
+        const expected = '1970-05-09 22:25:11';
+        const newVal = formatDateTime(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatDayHours timestamp to MM-DD HH:mm', () => {
+        const dateTime = 1627457470000;
+        const expected = '07-28 15:31';
+        const newVal = formatDayHours(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatDayHours string to MM-DD HH:mm', () => {
+        const dateTime = '07-28 15:31';
+        const expected = '07-28 15:31';
+        const newVal = formatDayHours(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatDayHours number to MM-DD HH:mm', () => {
+        const dateTime = 11111111111;
+        const expected = '05-09 22:25';
+        const newVal = formatDayHours(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatHours timestamp to HH:mm', () => {
+        const dateTime = 1627457470000;
+        const expected = '15:31';
+        const newVal = formatHours(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatHours string to HH:mm', () => {
+        const dateTime = '07-28 15:31';
+        const expected = '15:31';
+        const newVal = formatHours(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatHours number to HH:mm', () => {
+        const dateTime = 11111111111;
+        const expected = '22:25';
+        const newVal = formatHours(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatMinute timestamp to HH:mm:ss', () => {
+        const dateTime = 1627457470000;
+        const expected = '15:31:10';
+        const newVal = formatMinute(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatMinute string to HH:mm:ss', () => {
+        const dateTime = '08-22 15:31:10';
+        const expected = '15:31:10';
+        const newVal = formatMinute(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatMinute number to HH:mm:ss', () => {
+        const dateTime = 11111111111;
+        const expected = '22:25:11';
+        const newVal = formatMinute(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+});

--- a/test/dateTime.test.ts
+++ b/test/dateTime.test.ts
@@ -6,6 +6,7 @@ const {
     formatDayHours,
     formatHours,
     formatMinute,
+    formatSecond,
 } = DateTime;
 
 describe('utils.dateTime', () => {
@@ -115,6 +116,24 @@ describe('utils.dateTime', () => {
         const dateTime = 11111111111;
         const expected = '22:25:11';
         const newVal = formatMinute(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatSecond number to HH[h]mm[m]ss[s]', () => {
+        const dateTime = 11111;
+        const expected = '3h5m11s';
+        const newVal = formatSecond(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatSecond number to mm[m]ss[s]', () => {
+        const dateTime = 111;
+        const expected = '1m51s';
+        const newVal = formatSecond(dateTime);
+        expect(newVal).toEqual(expected);
+    });
+    test('formatSecond number to ss[s]', () => {
+        const dateTime = 11;
+        const expected = '11s';
+        const newVal = formatSecond(dateTime);
         expect(newVal).toEqual(expected);
     });
 });

--- a/test/localDB.test.ts
+++ b/test/localDB.test.ts
@@ -1,0 +1,54 @@
+// storage.test.js
+
+import LocalDB from '../src/localDB';
+
+const fakeLocalStorage = (function () {
+    let store = {};
+
+    return {
+        store,
+        getItem: function (key) {
+            return this[key] || null;
+        },
+        setItem: function (key, value) {
+            this[key] = value.toString();
+        },
+        removeItem: function (key) {
+            delete this[key];
+        },
+        clear: function () {
+            store = {};
+        },
+    };
+})();
+
+describe('utils.LocalDB', () => {
+    beforeAll(() => {
+        const localSProxy = new Proxy(fakeLocalStorage, {
+            get: function (target, property) {
+                if (target.store[property]) {
+                    return target.store[property];
+                }
+                return target[property];
+            },
+        });
+        Object.defineProperty(window, 'localStorage', {
+            value: localSProxy,
+        });
+    });
+
+    test('get the key to the string storage', () => {
+        window.localStorage.setItem('loglevel:webpack-dev-server', 'SILENT');
+        const value = LocalDB.get('loglevel:webpack-dev-server');
+        const expected = 'SILENT';
+        expect(value).toEqual(expected);
+    });
+    test('get the key to the json string storage', () => {
+        window.localStorage.setItem('jsonStr', '{"string":1}');
+        const value = LocalDB.get('jsonStr');
+        const expected = {
+            string: 1,
+        };
+        expect(value).toEqual(expected);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2507,6 +2507,11 @@ dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
 
+dayjs@^1.10.6:
+  version "1.10.6"
+  resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz#288b2aa82f2d8418a6c9d4df5898c0737ad02a63"
+  integrity sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -5267,10 +5272,6 @@ mkdirp@0.x, mkdirp@^0.5.1:
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
-
-moment@^2.27.0:
-  version "2.27.0"
-  resolved "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
从 dt-common 迁移方法。
1、增加 `dateTime` 时间格式化文件，单元测试与文档。其中 dt-common 中的 formatTime 方法，改名为 formatSecond
2、优化 `LocalDB` 中的 `get` 方法，并增加单元测试
3、修改 `getCookie`、`setCookie` 方法