### PR TITLE
fix: fix cant download json

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -336,6 +336,20 @@ mergeDeep(
 )
 // { a: 'cover', b: 321, c: 456, innerObj: { a: 'cover', b: 321, c: 456 } }
 ```
+## downloadData
+处理下载文件
+如果不传文件名fileName，会从`response`的`Content-disposition`读取
+
+```js
+downLoadData({
+    url: 'downloadUrl',
+    payload: { a: 1, b: 2 },
+    fileName: 'test.pdf',
+    successCallback: () => message.info('下载成功'),
+    errorCallback: () => message.error('下载失败'),
+    finallyCallback: () => this.setState({ visiable: false })
+})
+```
 
 ## isUtf8
 判断字符串格式是否为 utf-8


### PR DESCRIPTION
#53 

之前下载JSON文件有问题，是因为使用response.json来做catch，如果能被序列化则走errorCallback，反正successCallback

目前的改法为，改成使用content-type来判断。如果content-type为application/json，那么后端范围的一定不是我们需要的下载的文件，用errorCallback处理；反之，使用successCallback