### PR TITLE
perf(upgrade dayjs's version): upgrade dayjs's version and  set default timezone for dayjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "vue-cli-plugin-commitlint": "^1.0.4"
     },
     "dependencies": {
-        "dayjs": "^1.10.6",
+        "dayjs": "^1.11.13",
         "lodash": "^4.17.21",
         "standard-version": "^9.3.1"
     },

--- a/src/dateTime.ts
+++ b/src/dateTime.ts
@@ -4,6 +4,19 @@
  */
 
 import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone'; // ES 2015
+import utc from 'dayjs/plugin/utc'; // ES 2015
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+// 默认时区
+const DEFAULT_TIMEZONE = 'Asia/Shanghai';
+/**
+ * 将时间转换为默认时区
+ * @param {string | number | Date} time - 输入时间
+ * @return {dayjs.Dayjs} 带时区的Dayjs对象
+ */
+const toLocalTime = (...args) => dayjs(...args).tz(DEFAULT_TIMEZONE);
 
 /**
  * 时间处理
@@ -15,7 +28,7 @@ const dateTime = {
      * @return {string}
      */
     formatDateTime(timeData: string | number | Date) {
-        return dayjs(timeData).format('YYYY-MM-DD HH:mm:ss');
+        return toLocalTime(timeData).format('YYYY-MM-DD HH:mm:ss');
     },
     /**
      * 返回 YYYY-MM-DD 格式化的字符串
@@ -23,7 +36,7 @@ const dateTime = {
      * @return {string}
      */
     formatDate(timeData: string | number | Date) {
-        return dayjs(timeData).format('YYYY-MM-DD');
+        return toLocalTime(timeData).format('YYYY-MM-DD');
     },
     /**
      * 返回 YYYY-MM-DD HH:mm 格式化的字符串
@@ -31,7 +44,7 @@ const dateTime = {
      * @return {string}
      */
     formatDateHours(timeData: string | number | Date) {
-        return dayjs(timeData).format('YYYY-MM-DD HH:mm');
+        return toLocalTime(timeData).format('YYYY-MM-DD HH:mm');
     },
     /**
      * 返回 MM-DD HH:mm 格式化的字符串
@@ -39,7 +52,7 @@ const dateTime = {
      * @return {string}
      */
     formatDayHours(timeData: string | number | Date) {
-        return dayjs(timeData).format('MM-DD HH:mm');
+        return toLocalTime(timeData).format('MM-DD HH:mm');
     },
     /**
      * 返回 HH:mm 格式化的字符串
@@ -47,7 +60,7 @@ const dateTime = {
      * @return {string}
      */
     formatHours(timeData: string | number | Date) {
-        return dayjs(timeData).format('HH:mm');
+        return toLocalTime(timeData).format('HH:mm');
     },
     /**
      * 返回 HH:mm:ss 格式化的字符串
@@ -55,7 +68,7 @@ const dateTime = {
      * @return {string}
      */
     formatMinute(timeData: string | number | Date) {
-        return dayjs(timeData).format('HH:mm:ss');
+        return toLocalTime(timeData).format('HH:mm:ss');
     },
     /**
      * 把秒转换成 HH[h]mm[m]ss[s] 的格式

--- a/yarn.lock
+++ b/yarn.lock
@@ -3573,10 +3573,10 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-dayjs@^1.10.6:
-  version "1.11.5"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.5.tgz#00e8cc627f231f9499c19b38af49f56dc0ac5e93"
-  integrity sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==
+dayjs@^1.11.13:
+  version "1.11.13"
+  resolved "https://registry.npmmirror.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
+  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
## Do What
Upgrade dayjs's version and  set default timezone for dayjs.

### Change
Upgrade dayjs's version to 1.11.13. Then set default timezone to 'Asia/Shanghai'.

### Where
By default, the time zone for on-site client displays is configured as UTC+8 (China Standard Time) unless otherwise specified.
默认无特殊情况下，将客户现场显示的时间都定位到东八区去显示。