### PR TITLE
ci: update cache actions/cache's version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,10 +15,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Cache yarn.lock
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: package-temp-dir
                   key: lock-${{ github.sha }}
@@ -34,7 +34,7 @@ jobs:
                   cp yarn.lock package-temp-dir
             - name: Cache node_modules
               id: node_modules_cache_id
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: node_modules
                   key: node_modules-${{ hashFiles('**/package-temp-dir/yarn.lock') }}
@@ -50,13 +50,13 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Restore cache from yarn.lock
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: package-temp-dir
                   key: lock-${{ github.sha }}
 
             - name: Restore cache from node_modules
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: node_modules
                   key: node_modules-${{ hashFiles('**/package-temp-dir/yarn.lock') }}
@@ -71,13 +71,13 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Restore cache from yarn.lock
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: package-temp-dir
                   key: lock-${{ github.sha }}
 
             - name: Restore cache from node_modules
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: node_modules
                   key: node_modules-${{ hashFiles('**/package-temp-dir/yarn.lock') }}
@@ -92,13 +92,13 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Restore cache from yarn.lock
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: package-temp-dir
                   key: lock-${{ github.sha }}
 
             - name: Restore cache from node_modules
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: node_modules
                   key: node_modules-${{ hashFiles('**/package-temp-dir/yarn.lock') }}
@@ -118,13 +118,13 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Restore cache from yarn.lock
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: package-temp-dir
                   key: lock-${{ github.sha }}
 
             - name: Restore cache from node_modules
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: node_modules
                   key: node_modules-${{ hashFiles('**/package-temp-dir/yarn.lock') }}


### PR DESCRIPTION
## CI 
GitHub Actions 的 runner 无法解析 actions/cache@v2 的下载位置，更新 actions/cache 版本