### PR TITLE
fix: fix copy operation not working

### DIFF
--- a/src/copy/__test__/createFakeElement.test.ts
+++ b/src/copy/__test__/createFakeElement.test.ts
@@ -30,7 +30,7 @@ describe('createFakeElement', () => {
         expect(element.style.position).toBe('absolute');
         expect(element.style.left).toBe('-9999px');
         expect(element.style.opacity).toBe('0');
-        expect(element.style.visibility).toBe('hidden');
+        expect(element.style.visibility).not.toBe('hidden');
     });
 
     test('sets correct styles in RTL mode', () => {

--- a/src/copy/createFakeElement.ts
+++ b/src/copy/createFakeElement.ts
@@ -14,7 +14,6 @@ function createFakeElement(value: string): HTMLTextAreaElement {
      * 将元素水平移出屏幕
      */
     Object.assign(fakeElement.style, {
-        visibility: 'hidden',
         opacity: '0',
         position: 'absolute',
         top: `${window.pageYOffset || document.documentElement.scrollTop}px`,


### PR DESCRIPTION
## 变更内容
- 移除 fake 元素的 `visibility: 'hidden'` 样式

## 变更原因
- 使用visibility 隐藏会导致复制不成功