### PR TITLE
fix: handle edge cases for invalid and negative values

### DIFF
--- a/docs/api/functions/formatBytes.md
+++ b/docs/api/functions/formatBytes.md
@@ -12,9 +12,9 @@ Defined in: [formatBytes/index.ts:49](https://github.com/DTStack/dt-utils/blob/m
 
 ### value
 
-`number`
-
 要格式化的字节数值
+
+`string` | `number`
 
 ### decimals?
 

--- a/src/formatBytes/__test__/index.test.ts
+++ b/src/formatBytes/__test__/index.test.ts
@@ -12,6 +12,11 @@ describe('formatBytes', () => {
             expect(formatBytes(-1024)).toBe('Invalid value');
         });
 
+        test('should handle numeric string inputs', () => {
+            expect(formatBytes('1024')).toBe('1 KB');
+            expect(formatBytes('0')).toBe('0 B');
+        });
+
         test('should return 0 B for zero', () => {
             expect(formatBytes(0)).toBe('0 B');
         });
@@ -21,6 +26,13 @@ describe('formatBytes', () => {
         test('should correctly convert bytes (B)', () => {
             expect(formatBytes(1)).toBe('1 B');
             expect(formatBytes(1023)).toBe('1023 B');
+        });
+
+        test('should handle fractional bytes (0 < value < 1)', () => {
+            expect(formatBytes(0.5)).toBe('0.5 B');
+            expect(formatBytes(0.1)).toBe('0.1 B');
+            expect(formatBytes(0.123, 3)).toBe('0.123 B');
+            expect(formatBytes(0.999)).toBe('1 B');
         });
 
         test('should correctly convert kilobytes (KB)', () => {

--- a/src/formatBytes/index.ts
+++ b/src/formatBytes/index.ts
@@ -17,7 +17,7 @@ type FormattedBytes = `${number} ${ByteUnit}` | 'Invalid value' | '0 B';
  * - 当输入为负数、NaN或Infinity时，返回"Invalid value"
  * - 当输入为0时，返回"0 B"
  *
- * @param {number} value - 要格式化的字节数值
+ * @param {number | string} value - 要格式化的字节数值
  * @param {number} [decimals=2] - 结果保留的小数位数，默认为2位
  * @returns {FormattedBytes} 格式化后的字符串，例如"1.5 MB"。若输入无效则返回"Invalid value"
  *
@@ -46,18 +46,19 @@ type FormattedBytes = `${number} ${ByteUnit}` | 'Invalid value' | '0 B';
  *
  * @see {@link https://en.wikipedia.org/wiki/Byte#Multiple-byte_units} 查看更多关于字节单位的信息
  */
-const formatBytes = (value: number, decimals = 2): FormattedBytes => {
-    if (!Number.isFinite(value)) return 'Invalid value';
-    if (value < 0) return 'Invalid value';
-    if (value === 0) return '0 B';
+const formatBytes = (value: number | string, decimals = 2): FormattedBytes => {
+    const normalizedValue = Number(value);
+    if (!Number.isFinite(normalizedValue)) return 'Invalid value';
+    if (normalizedValue < 0) return 'Invalid value';
+    if (normalizedValue === 0) return '0 B';
 
     const UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'] as const;
     const BYTES_PER_UNIT = 1024;
 
-    const unitLevel = Math.floor(Math.log(value) / Math.log(BYTES_PER_UNIT));
+    const unitLevel = Math.max(0, Math.floor(Math.log(normalizedValue) / Math.log(BYTES_PER_UNIT)));
     const normalizedLevel = Math.min(unitLevel, UNITS.length - 1);
 
-    const finalValue = value / Math.pow(BYTES_PER_UNIT, normalizedLevel);
+    const finalValue = normalizedValue / Math.pow(BYTES_PER_UNIT, normalizedLevel);
     const formattedValue = Number(finalValue.toFixed(decimals)).toString();
 
     return `${formattedValue} ${UNITS[normalizedLevel]}` as FormattedBytes;


### PR DESCRIPTION
## 变更内容
- 添加 `Number(value)` 转换，支持字符串数字输入（如 "1024"）
- 添加 `Math.max(0, ...)` 保护，防止 0 到 1 之间的小数值产生负的单位级别

## 变更原因
- 处理传入数字字符串的场景
- 修复 `Math.log` 对 0 到 1 之间的小数值返回负数的问题
