### PR TITLE
feat: support query parameters in hash fragment

### DIFF
--- a/docs/api/functions/getQueryParameter.md
+++ b/docs/api/functions/getQueryParameter.md
@@ -4,7 +4,7 @@
 
 > **getQueryParameter**(`name`, `url?`): `undefined` \| `null` \| `string` \| `number` \| `boolean`
 
-Defined in: [getQueryParameter/index.ts:35](https://github.com/DTStack/dt-utils/blob/master/src/getQueryParameter/index.ts#L35)
+Defined in: [getQueryParameter/index.ts:38](https://github.com/DTStack/dt-utils/blob/master/src/getQueryParameter/index.ts#L38)
 
 从给定的 URL 中获取指定查询参数的值。
 
@@ -52,4 +52,7 @@ getQueryParameter('count', 'https://example.com?isActive=true&count=null'); // =
 // 不传入 url 时使用当前页面 URL
 // 若当前页面 URL 为 https://current.com?page=home&limit=10
 getQueryParameter('limit'); // => 10
+
+// 从 hash 片段解析参数
+getQueryParameter('page', 'https://example.com/#/hash?page=home&limit=10'); // => "home"
 ```

--- a/src/getQueryParameter/__test__/index.test.ts
+++ b/src/getQueryParameter/__test__/index.test.ts
@@ -1,7 +1,8 @@
 import getQueryParameter from '..';
 
 describe('getQueryParameter', () => {
-    it('should return the parsed value for a parameter from the provided url', () => {
+    it('should return the string value for a parameter from the provided url', () => {
+        expect(getQueryParameter('name', 'https://example.com?name=john&age=25')).toBe('john');
         expect(getQueryParameter('age', 'https://example.com?name=john&age=25')).toBe(25);
         expect(getQueryParameter('enabled', 'https://example.com?enabled=true')).toBe(true);
     });
@@ -32,5 +33,35 @@ describe('getQueryParameter', () => {
     it('should preserve special parsed values from the query string', () => {
         expect(getQueryParameter('empty', 'https://example.com?empty=null')).toBeNull();
         expect(getQueryParameter('unset', 'https://example.com?unset=undefined')).toBeUndefined();
+    });
+
+    it('should parse query parameters from hash fragment', () => {
+        expect(getQueryParameter('token', 'https://example.com#hash?token=abc123')).toBe('abc123');
+    });
+
+    it('should prioritize search params over hash params', () => {
+        expect(getQueryParameter('key', 'https://example.com?key=search#hash?key=hash')).toBe(
+            'search'
+        );
+    });
+
+    it('should return hash param when search param does not exist', () => {
+        expect(
+            getQueryParameter('hashOnly', 'https://example.com?page=1#hash?hashOnly=value')
+        ).toBe('value');
+    });
+
+    it('should return undefined when hash has no query string', () => {
+        expect(getQueryParameter('name', 'https://example.com/#/path/to/page')).toBeUndefined();
+    });
+
+    it('should return undefined when hash has question mark but no params', () => {
+        expect(getQueryParameter('name', 'https://example.com/#/path?')).toBeUndefined();
+    });
+
+    it('should decode encoded characters in hash params', () => {
+        expect(getQueryParameter('name', 'https://example.com/#/path?name=hello%20world')).toBe(
+            'hello world'
+        );
     });
 });

--- a/src/getQueryParameter/index.ts
+++ b/src/getQueryParameter/index.ts
@@ -14,7 +14,7 @@ import getQueryParameters from '../getQueryParameters';
  *
  * @param {string} name - 要获取的查询参数名
  * @param {string} [url] - 目标 URL，若未提供则使用当前页面的 window.location.href
- * @returns {string | null | undefined | number | boolean} - 解析后的查询参数值
+ * @returns {string | number | boolean | undefined | null} - 解析后的查询参数值
  *
  * @example
  * ```typescript
@@ -30,13 +30,23 @@ import getQueryParameters from '../getQueryParameters';
  * // 不传入 url 时使用当前页面 URL
  * // 若当前页面 URL 为 https://current.com?page=home&limit=10
  * getQueryParameter('limit'); // => 10
+ *
+ * // 从 hash 片段解析参数
+ * getQueryParameter('page', 'https://example.com/#/hash?page=home&limit=10'); // => "home"
  * ```
  */
 const getQueryParameter = (name: string, url?: string) => {
     try {
         const targetUrl = url || window.location.href;
-        const search = new URL(targetUrl).search;
-        const params = getQueryParameters(search);
+        const parsedUrl = new URL(targetUrl);
+        let params = getQueryParameters(parsedUrl.search);
+
+        if (parsedUrl.hash.includes('?')) {
+            const hashSearch = parsedUrl.hash.slice(parsedUrl.hash.indexOf('?') + 1);
+            const hashParams = getQueryParameters(hashSearch);
+
+            params = { ...hashParams, ...params };
+        }
 
         return params[name];
     } catch (error: unknown) {


### PR DESCRIPTION
## 变更内容
- 支持从 URL hash 中解析查询参数（如 `page#hash?param=value`）

## 变更原因
- 单页应用常使用 hash 路由，需要支持 hash 片段中的查询参数