### PR TITLE
fix: improve type safety and support synchronous return for strings

### DIFF
--- a/docs/api/functions/toBase64.md
+++ b/docs/api/functions/toBase64.md
@@ -2,25 +2,7 @@
 
 # Function: toBase64()
 
-> **toBase64**(`value`): `Promise`\<`undefined` \| `null` \| `string`\>
-
-Defined in: [toBase64/index.ts:32](https://github.com/DTStack/dt-utils/blob/master/src/toBase64/index.ts#L32)
-
 将值转换为Base64编码的字符串。
-
-## Parameters
-
-### value
-
-需要转换为Base64的值。支持File、string或其他原始类型
-
-`string` | `Blob` | `File`
-
-## Returns
-
-`Promise`\<`undefined` \| `null` \| `string`\>
-
-返回一个Promise，解析为Base64编码的字符串。如果输入为null/undefined则返回原始值
 
 ## Example
 
@@ -41,3 +23,47 @@ console.log(base64File); // 'data:text/plain;base64,ZmlsZSBjb250ZW50'
 const result = await toBase64(null);
 console.log(result); // null
 ```
+
+## Call Signature
+
+> **toBase64**(`value`): `undefined` \| `string`
+
+Defined in: [toBase64/index.ts:9](https://github.com/DTStack/dt-utils/blob/master/src/toBase64/index.ts#L9)
+
+将字符串转换为Base64编码的字符串。
+
+### Parameters
+
+#### value
+
+需要转换为Base64的字符串，支持null/undefined
+
+`undefined` | `null` | `string`
+
+### Returns
+
+`undefined` \| `string`
+
+Base64编码的字符串，如果输入为null/undefined则返回undefined
+
+## Call Signature
+
+> **toBase64**(`value`): `Promise`\<`null` \| `string` \| `ArrayBuffer`\>
+
+Defined in: [toBase64/index.ts:17](https://github.com/DTStack/dt-utils/blob/master/src/toBase64/index.ts#L17)
+
+将File或Blob对象转换为Base64编码的Data URL。
+
+### Parameters
+
+#### value
+
+需要转换为Base64的File或Blob对象
+
+`Blob` | `File`
+
+### Returns
+
+`Promise`\<`null` \| `string` \| `ArrayBuffer`\>
+
+Promise，解析为Base64编码的Data URL字符串

--- a/docs/api/functions/toBase64.md
+++ b/docs/api/functions/toBase64.md
@@ -11,17 +11,17 @@ import { toBase64 } from 'dt-utils';
 
 // 将字符串转换为Base64
 const str = 'Hello World';
-const base64Str = await toBase64(str);
+const base64Str = toBase64(str);
 console.log(base64Str); // 'SGVsbG8gV29ybGQ='
+
+// 处理null值
+const result = toBase64(null);
+console.log(result); // null
 
 // 将文件转换为Base64
 const file = new File(['file content'], 'test.txt');
 const base64File = await toBase64(file);
 console.log(base64File); // 'data:text/plain;base64,ZmlsZSBjb250ZW50'
-
-// 处理null值
-const result = await toBase64(null);
-console.log(result); // null
 ```
 
 ## Call Signature

--- a/src/toBase64/__test__/index.test.ts
+++ b/src/toBase64/__test__/index.test.ts
@@ -1,39 +1,43 @@
 import toBase64 from '../index';
 
 describe('toBase64', () => {
-    it('should return a resolved promise with undefined when input is undefined', async () => {
-        await expect(toBase64(undefined)).resolves.toBeUndefined();
+    it('should return undefined when input is undefined', () => {
+        expect(toBase64(undefined)).toBeUndefined();
     });
 
-    it('should return a resolved promise with null when input is null', async () => {
-        await expect(toBase64(null)).resolves.toBeNull();
+    it('should return undefined when input is null', () => {
+        expect(toBase64(null)).toBeUndefined();
     });
 
-    it('should encode a string to Base64 using js-base64', async () => {
-        await expect(toBase64('hello')).resolves.toBe('aGVsbG8=');
-    });
-
-    it('should encode a number to Base64 using js-base64', async () => {
-        await expect(toBase64(12345)).resolves.toBe('MTIzNDU=');
+    it('should encode a string to Base64 synchronously', () => {
+        expect(toBase64('hello')).toBe('aGVsbG8=');
     });
 
     it('should encode a Blob to Base64', async () => {
         const blob = new Blob(['hello world'], { type: 'text/plain' });
         const base64Result = await toBase64(blob);
-        expect(base64Result.startsWith('data:text/plain;base64,')).toBe(true);
+        expect(String(base64Result).startsWith('data:text/plain;base64,')).toBe(true);
     });
 
     it('should encode a File to Base64', async () => {
         const file = new File(['file content'], 'test.txt', { type: 'text/plain' });
         const base64Result = await toBase64(file);
-        expect(base64Result.startsWith('data:text/plain;base64,')).toBe(true);
+        expect(String(base64Result).startsWith('data:text/plain;base64,')).toBe(true);
     });
 
     it('should reject when FileReader encounters an error', async () => {
         const mockBlob = new Blob(['test'], { type: 'text/plain' });
-        jest.spyOn(FileReader.prototype, 'readAsDataURL').mockImplementation(function () {
-            setTimeout(() => this.onerror && this.onerror(new Error('FileReader error')));
+        jest.spyOn(FileReader.prototype, 'readAsDataURL').mockImplementation(function (
+            this: FileReader
+        ) {
+            setTimeout(() => {
+                if (this.onerror) {
+                    this.onerror(
+                        new ProgressEvent('error') as unknown as ProgressEvent<FileReader>
+                    );
+                }
+            });
         });
-        await expect(toBase64(mockBlob)).rejects.toThrow('FileReader error');
+        await expect(toBase64(mockBlob)).rejects.toBeDefined();
     });
 });

--- a/src/toBase64/__test__/index.test.ts
+++ b/src/toBase64/__test__/index.test.ts
@@ -32,12 +32,10 @@ describe('toBase64', () => {
         ) {
             setTimeout(() => {
                 if (this.onerror) {
-                    this.onerror(
-                        new ProgressEvent('error') as unknown as ProgressEvent<FileReader>
-                    );
+                    this.onerror(new ProgressEvent('error') as ProgressEvent<FileReader>);
                 }
             });
         });
-        await expect(toBase64(mockBlob)).rejects.toBeDefined();
+        await expect(toBase64(mockBlob)).rejects.toBeInstanceOf(ProgressEvent);
     });
 });

--- a/src/toBase64/index.ts
+++ b/src/toBase64/index.ts
@@ -26,17 +26,17 @@ function toBase64(value: File | Blob): Promise<string | ArrayBuffer | null>;
  *
  * // 将字符串转换为Base64
  * const str = 'Hello World';
- * const base64Str = await toBase64(str);
+ * const base64Str = toBase64(str);
  * console.log(base64Str); // 'SGVsbG8gV29ybGQ='
+ *
+ * // 处理null值
+ * const result = toBase64(null);
+ * console.log(result); // null
  *
  * // 将文件转换为Base64
  * const file = new File(['file content'], 'test.txt');
  * const base64File = await toBase64(file);
  * console.log(base64File); // 'data:text/plain;base64,ZmlsZSBjb250ZW50'
- *
- * // 处理null值
- * const result = await toBase64(null);
- * console.log(result); // null
  * ```
  */
 function toBase64(value: File | Blob | string | null | undefined) {

--- a/src/toBase64/index.ts
+++ b/src/toBase64/index.ts
@@ -1,14 +1,24 @@
 import { toBase64 as _toBase64 } from 'js-base64';
 
-import getTypeOfValue from '../getTypeOfValue';
+/**
+ * 将字符串转换为Base64编码的字符串。
+ *
+ * @param {string | null | undefined} value - 需要转换为Base64的字符串，支持null/undefined
+ * @returns {string | undefined} Base64编码的字符串，如果输入为null/undefined则返回undefined
+ */
+function toBase64(value: string | null | undefined): string | undefined;
 
+/**
+ * 将File或Blob对象转换为Base64编码的Data URL。
+ *
+ * @param {File | Blob} value - 需要转换为Base64的File或Blob对象
+ * @returns {Promise<string | ArrayBuffer | null>} Promise，解析为Base64编码的Data URL字符串
+ */
+function toBase64(value: File | Blob): Promise<string | ArrayBuffer | null>;
 /**
  * 将值转换为Base64编码的字符串。
  *
  * @category 转换
- *
- * @param {File | Blob | string} value - 需要转换为Base64的值。支持File、string或其他原始类型
- * @returns {Promise<string | null | undefined>} 返回一个Promise，解析为Base64编码的字符串。如果输入为null/undefined则返回原始值
  *
  * @example
  * ```typescript
@@ -29,19 +39,19 @@ import getTypeOfValue from '../getTypeOfValue';
  * console.log(result); // null
  * ```
  */
-const toBase64 = (value: File | Blob | string): Promise<string | null | undefined> => {
-    if (value === undefined || value === null) return Promise.resolve(value);
+function toBase64(value: File | Blob | string | null | undefined) {
+    if (value === undefined || value === null) return undefined;
+
+    if (!(value instanceof Blob)) {
+        return _toBase64(value);
+    }
 
     return new Promise((resolve, reject) => {
-        if (['blob', 'file'].includes(getTypeOfValue(value))) {
-            const reader = new FileReader();
-            reader.readAsDataURL(value as File | Blob);
-            reader.onload = () => resolve(reader.result as string);
-            reader.onerror = (error) => reject(error);
-        } else {
-            resolve(_toBase64(String(value)));
-        }
+        const reader = new FileReader();
+        reader.readAsDataURL(value);
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = (error) => reject(error);
     });
-};
+}
 
 export default toBase64;


### PR DESCRIPTION
## 变更内容
- 添加函数重载，提升类型推断能力
- 字符串输入时同步返回 `string | undefined`，无需异步操作
- File/Blob 输入时返回 `Promise<string | ArrayBuffer | null>`
- 使用 `instanceof Blob` 替代 `getTypeOfValue` 进行类型检查
- 移除对 `getTypeOfValue` 的依赖

## 变更原因
- 字符串编码不需要异步操作，同步返回即可
- 提升 TypeScript 类型安全性和开发体验